### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Performs integrated tests with [FakePlayer by Muqsit](https://github.com/muqsit/
 ## PHPStan & PHP-CS-Fixer
 Common PHP dev tools:
 - [PHPStan](https://github.com/phpstan/phpstan): lint. (static code check.)
-- [PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer): fixes code standard. (Format code, replace FQCN with `use`, etc... Do not get confused with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer)!)
+- [PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer): fixes code standard. (Format code, replace FQCN with `use`, etc... Do not get confused with [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer)!)
 
 # Credit
 - Icon from https://windows93.net


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932